### PR TITLE
fix vendor path in cake shell

### DIFF
--- a/app/Console/cake.php
+++ b/app/Console/cake.php
@@ -28,7 +28,7 @@ if (function_exists('ini_set')) {
 	$root = dirname(dirname(dirname(__FILE__)));
 	$appDir = basename(dirname(dirname(__FILE__)));
 	$install = $root . DS . 'lib';
-	$composerInstall = $root . DS . $appDir . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
+	$composerInstall = $root . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
 
 	// the following lines differ from its sibling
 	// /app/Console/cake.php

--- a/app2/Console/cake.php
+++ b/app2/Console/cake.php
@@ -28,7 +28,7 @@ if (function_exists('ini_set')) {
 	$root = dirname(dirname(dirname(__FILE__)));
 	$appDir = basename(dirname(dirname(__FILE__)));
 	$install = $root . DS . 'lib';
-	$composerInstall = $root . DS . $appDir . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
+	$composerInstall = $root . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
 
 	// the following lines differ from its sibling
 	// /app/Console/cake.php


### PR DESCRIPTION
@mongorian-chop we get a trivial trouble.

sometimes we try testing in project separately.
when execute below commands,
```
cd APP_DIR
phing local-build
``` 

results: 
```
     [exec] PHP Warning:  include(Cake/Console/ShellDispatcher.php): failed to open stream: No such file or directory in /var/www/vhosts/admin/app2/Console/cake.php on line 45
```

in this repo, `Vendor` directory is moved to ROOT directory, so i have modified install path.